### PR TITLE
Restructure: Move tests and rename library

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -30,17 +30,17 @@ jobs:
         with:
           submodules: recursive
       - name: Build binary framework
-        run: make framework # produces './generated/RustFramework.xcframework'
+        run: make framework # produces './generated/ConcordiumWalletCrypto.xcframework'
       - name: Archive framework
         working-directory: ./generated
         run: |
-          zip -r ./RustFramework.xcframework.zip ./RustFramework.xcframework
-          swift package compute-checksum ./RustFramework.xcframework.zip > ./CHECKSUM
+          zip -r ./ConcordiumWalletCrypto.xcframework.zip ./ConcordiumWalletCrypto.xcframework
+          swift package compute-checksum ./ConcordiumWalletCrypto.xcframework.zip > ./CHECKSUM
       - name: Upload package as GitHub release
         uses: softprops/action-gh-release@v1
         with:
             files: |
-              ./generated/RustFramework.xcframework.zip
+              ./generated/ConcordiumWalletCrypto.xcframework.zip
               ./generated/CHECKSUM
             name: '${{github.event.inputs.version}}'
             generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Rename crate from "crypto" to "concordium-wallet-crypto-uniffi"
+- Rename generated framework from "RustFramework" to "ConcordiumWalletCrypto".
 - Bump UniFFI from v0.25.x to v0.26.x.
 
 ## [1.0.0] - 2024-02-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump UniFFI from v0.25.x to v0.26.x.
+
 ## [1.0.0] - 2024-02-06
 
 Migrate crypto library from `ConcordiumSwiftSdk`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -543,6 +543,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concordium-wallet-crypto-uniffi"
+version = "1.0.0"
+dependencies = [
+ "thiserror",
+ "uniffi",
+ "wallet_library",
+]
+
+[[package]]
 name = "concordium_base"
 version = "4.0.0"
 dependencies = [
@@ -643,15 +652,6 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
-
-[[package]]
-name = "crypto"
-version = "1.0.0"
-dependencies = [
- "thiserror",
- "uniffi",
- "wallet_library",
-]
 
 [[package]]
 name = "crypto-common"
@@ -909,9 +909,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "goblin"
-version = "0.6.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6b4de4a8eb6c46a8c77e1d3be942cb9a8bf073c22374578e5ba4b08ed0ff68"
+checksum = "bb07a4ffed2093b118a525b1d8f5204ae274faed5604537caf7135d0f18d9887"
 dependencies = [
  "log",
  "plain",
@@ -1538,18 +1538,18 @@ checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
 
 [[package]]
 name = "scroll"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
+checksum = "6ab8598aa408498679922eff7fa985c25d58a90771bd6be794434c5277eab1a6"
 dependencies = [
  "scroll_derive",
 ]
 
 [[package]]
 name = "scroll_derive"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1674,6 +1674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1740,6 +1746,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
 
 [[package]]
 name = "thiserror"
@@ -1853,10 +1870,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
-name = "uniffi"
-version = "0.25.3"
+name = "unicode-linebreak"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21345172d31092fd48c47fd56c53d4ae9e41c4b1f559fb8c38c1ab1685fd919f"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "uniffi"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ad0be8bba6c242d2d16922de4a9c8f167b9491729fda552e70f8626bf7302cb"
 dependencies = [
  "anyhow",
  "camino",
@@ -1869,9 +1898,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_bindgen"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd992f2929a053829d5875af1eff2ee3d7a7001cb3b9a46cc7895f2caede6940"
+checksum = "ab31006ab9c9c6870739f0e74235729d1478d82e73571b8f53c25aa176d67535"
 dependencies = [
  "anyhow",
  "askama",
@@ -1885,6 +1914,7 @@ dependencies = [
  "once_cell",
  "paste",
  "serde",
+ "textwrap",
  "toml",
  "uniffi_meta",
  "uniffi_testing",
@@ -1893,9 +1923,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_build"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "001964dd3682d600084b3aaf75acf9c3426699bc27b65e96bb32d175a31c74e9"
+checksum = "4aa3a7608c6872dc1ce53199d816a24d2e19af952d82ce557ecc8692a4ae9cba"
 dependencies = [
  "anyhow",
  "camino",
@@ -1904,9 +1934,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_checksum_derive"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55137c122f712d9330fd985d66fa61bdc381752e89c35708c13ce63049a3002c"
+checksum = "72775b3afa6adb30e0c92b3107858d2fcb0ff1a417ac242db1f648b0e2dd0ef2"
 dependencies = [
  "quote",
  "syn 2.0.48",
@@ -1914,9 +1944,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_core"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6121a127a3af1665cd90d12dd2b3683c2643c5103281d0fed5838324ca1fad5b"
+checksum = "8d6e8db3f4e558faf0e25ac4b5bd775567973a4e18809f1123e74de52a853692"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1930,9 +1960,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_macros"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cf7a58f101fcedafa5b77ea037999b88748607f0ef3a33eaa0efc5392e92e4"
+checksum = "a126650799f97d97d8e38e3f10f15c65f5bc5a76b021bec21823efe9dd831a02"
 dependencies = [
  "bincode",
  "camino",
@@ -1949,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_meta"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dc8573a7b1ac4b71643d6da34888273ebfc03440c525121f1b3634ad3417a2"
+checksum = "3f64a99e905671738d9d293f9cce58708ce1af8e13ea29f9d6b6925114fc2e85"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1961,9 +1991,9 @@ dependencies = [
 
 [[package]]
 name = "uniffi_testing"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118448debffcb676ddbe8c5305fb933ab7e0123753e659a71dc4a693f8d9f23c"
+checksum = "cdca5719a22edf34c8239cc6ac9e3906d7ebc2a3e8a5e6ece4c3dffc312a4251"
 dependencies = [
  "anyhow",
  "camino",
@@ -1974,11 +2004,12 @@ dependencies = [
 
 [[package]]
 name = "uniffi_udl"
-version = "0.25.3"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "889edb7109c6078abe0e53e9b4070cf74a6b3468d141bdf5ef1bd4d1dc24a1c3"
+checksum = "3f6817c15714acccd0d0459f99b524cabebfdd622376464a2c6466a6485bdb4b"
 dependencies = [
  "anyhow",
+ "textwrap",
  "uniffi_meta",
  "uniffi_testing",
  "weedle2",
@@ -2078,9 +2109,9 @@ checksum = "4d91413b1c31d7539ba5ef2451af3f0b833a005eb27a631cec32bc0635a8602b"
 
 [[package]]
 name = "weedle2"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e79c5206e1f43a2306fd64bdb95025ee4228960f2e6c5a8b173f3caaf807741"
+checksum = "998d2c24ec099a87daf9467808859f9d82b61f1d9c9701251aea037f514eae0e"
 dependencies = [
  "nom",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
-name = "crypto"
+name = "concordium-wallet-crypto-uniffi"
 version = "1.0.0"
 edition = "2021"
 
 [lib]
 crate-type = ["staticlib", "lib"]
-name = "crypto"
 
 [dependencies]
 thiserror = "1"
-uniffi = { version = "0.25", features = ["cli"] }
+uniffi = { version = "0.26", features = ["cli"] }
 wallet_library = { path = "./concordium-base/rust-src/wallet_library" }
 
 [build-dependencies]
-uniffi = { version = "0.25", features = ["build"] }
+uniffi = { version = "0.26", features = ["build"] }
 
 [[bin]]
 name = "uniffi-bindgen"

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ setup:
 
 # BUILD FRAMEWORK #
 
-.PHONY: framework # produces './generated/RustFramework.xcframework'
+.PHONY: framework # produces './generated/ConcordiumWalletCrypto.xcframework'
 framework: clean-generated swift-bindings lib-darwin lib-ios lib-ios-sim
 	xcodebuild -create-xcframework \
 	  -library ./generated/target/universal-darwin/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
 	  -library ./target/aarch64-apple-ios/release/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
 	  -library ./generated/target/universal-ios/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
-	  -output ./generated/RustFramework.xcframework
+	  -output ./generated/ConcordiumWalletCrypto.xcframework
 
 # GENERATE BINDINGS #
 

--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ setup:
 .PHONY: framework # produces './generated/RustFramework.xcframework'
 framework: clean-generated swift-bindings lib-darwin lib-ios lib-ios-sim
 	xcodebuild -create-xcframework \
-	  -library ./generated/target/universal-darwin/libcrypto.a -headers ./generated/bindings \
-	  -library ./target/aarch64-apple-ios/release/libcrypto.a -headers ./generated/bindings \
-	  -library ./generated/target/universal-ios/libcrypto.a -headers ./generated/bindings \
+	  -library ./generated/target/universal-darwin/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
+	  -library ./target/aarch64-apple-ios/release/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
+	  -library ./generated/target/universal-ios/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
 	  -output ./generated/RustFramework.xcframework
 
 # GENERATE BINDINGS #
@@ -40,47 +40,48 @@ swift-bindings: # produces './generated/bindings'
 	$(cargo) run --bin=uniffi-bindgen generate src/lib.udl --language=swift --out-dir=./generated/bindings
 	mkdir -p ./Sources/ConcordiumWalletCrypto
 	# Move Swift bridge code to source folder.
-	# The remaining files (header and renamed modulemap) should go into the framework.
+	# The remaining files (header and renamed modulemap) should go into the framework
+	# (the directory is passed to 'xcodebuild -create-xcframework' via '-headers').
 	mv ./generated/bindings/crypto.swift ./Sources/ConcordiumWalletCrypto/crypto.swift
 	mv ./generated/bindings/cryptoFFI.modulemap ./generated/bindings/module.modulemap
 
 # BUILD STATIC LIBRARIES #
 
 .PHONY: lib-darwin-x86_64
-lib-darwin-x86_64: # produces './target/x86_64-apple-darwin/release/libcrypto.a'
+lib-darwin-x86_64: # produces './target/x86_64-apple-darwin/release/libconcordium_wallet_crypto_uniffi.a'
 	$(cargo) build --target=x86_64-apple-darwin --release
 
 .PHONY: lib-darwin-aarch64
-lib-darwin-aarch64: # produces './target/aarch64-apple-darwin/release/libcrypto.a'
+lib-darwin-aarch64: # produces './target/aarch64-apple-darwin/release/libconcordium_wallet_crypto_uniffi.a'
 	$(cargo) build --target=aarch64-apple-darwin --release
 
 .PHONY: lib-darwin
-lib-darwin: lib-darwin-x86_64 lib-darwin-aarch64 # produces './generated/target/universal-darwin/libcrypto.a'
+lib-darwin: lib-darwin-x86_64 lib-darwin-aarch64 # produces './generated/target/universal-darwin/libconcordium_wallet_crypto_uniffi.a'
 	mkdir -p ./generated/target/universal-darwin
 	lipo \
-	  ./target/x86_64-apple-darwin/release/libcrypto.a \
-	  ./target/aarch64-apple-darwin/release/libcrypto.a \
-	  -create -output ./generated/target/universal-darwin/libcrypto.a
+	  ./target/x86_64-apple-darwin/release/libconcordium_wallet_crypto_uniffi.a \
+	  ./target/aarch64-apple-darwin/release/libconcordium_wallet_crypto_uniffi.a \
+	  -create -output ./generated/target/universal-darwin/libconcordium_wallet_crypto_uniffi.a
 
-.PHONY: lib-ios # produces './target/aarch64-apple-ios/release/libcrypto.a'
+.PHONY: lib-ios # produces './target/aarch64-apple-ios/release/libconcordium_wallet_crypto_uniffi.a'
 lib-ios:
 	$(cargo) build --target=aarch64-apple-ios --release
 
-.PHONY: lib-ios-sim-x86_64 # produces './target/x86_64-apple-ios/release/libcrypto.a'
+.PHONY: lib-ios-sim-x86_64 # produces './target/x86_64-apple-ios/release/libconcordium_wallet_crypto_uniffi.a'
 lib-ios-sim-x86_64:
 	$(cargo) build --target=x86_64-apple-ios --release
 
-.PHONY: lib-ios-sim-aarch64 # produces './target/aarch64-apple-ios-sim/release/libcrypto.a'
+.PHONY: lib-ios-sim-aarch64 # produces './target/aarch64-apple-ios-sim/release/libconcordium_wallet_crypto_uniffi.a'
 lib-ios-sim-aarch64:
 	$(cargo) build --target=aarch64-apple-ios-sim --release
 
-.PHONY: lib-ios-sim # produces './generated/target/universal-ios/libcrypto.a'
+.PHONY: lib-ios-sim # produces './generated/target/universal-ios/libconcordium_wallet_crypto_uniffi.a'
 lib-ios-sim: lib-ios-sim-x86_64 lib-ios-sim-aarch64
 	mkdir -p ./generated/target/universal-ios
 	lipo \
-	  ./target/x86_64-apple-ios/release/libcrypto.a \
-	  ./target/aarch64-apple-ios-sim/release/libcrypto.a \
-	  -create -output ./generated/target/universal-ios/libcrypto.a
+	  ./target/x86_64-apple-ios/release/libconcordium_wallet_crypto_uniffi.a \
+	  ./target/aarch64-apple-ios-sim/release/libconcordium_wallet_crypto_uniffi.a \
+	  -create -output ./generated/target/universal-ios/libconcordium_wallet_crypto_uniffi.a
 
 # CLEANUP #
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version: 5.6
 
 import PackageDescription
 

--- a/README.md
+++ b/README.md
@@ -64,14 +64,17 @@ Run
 make framework
 ```
 
-This script will compile the sources into a framework `./generated/RustFramework.xcframework` that supports
+This script will compile the sources into a framework `./generated/ConcordiumWalletCrypto.xcframework`
+that supports the following platforms:
+
 - macOS: x86_64 (`x86_64-apple-darwin`) and ARM (`aarch64-apple-darwin`) as a universal binary
 - iOS: ARM (`aarch64-apple-ios`)
 - iOS simulator: x86_64 (`x86_64-apple-ios`) and ARM (`aarch64-apple-ios-sim`) as a universal binary.
 
 The makefile is structured such that the targets can be easily combined to build other combinations of architectures.
-The resulting framework is ready be integrated directly into an XCode project or a SwiftPM project as a binary target in `Package.swift`.
-In our [`Package.swift`](./Package.swift), the framework is fetched from a GitHub release as explained above.
+The resulting framework is ready be integrated directly into an XCode project or a SwiftPM project as a binary target
+in the project's `Package.swift` file.
+In our [`Package.swift`](./Package.swift), the framework is referring to a GitHub release as explained above.
 
 ## Development
 
@@ -101,7 +104,9 @@ The steps for building and releasing a new version `<version>` of the library ar
 4. Run `make swift-bindings` locally to regenerate the Swift bridge sources.
 5. Update `Package.swift` with the updated `url` and `checksum` of the binary framework.
    The workflow prints the checksum as the last step of its execution.
-6. Commit the changes and push an annotated tag named by the version for the new commit:
+6. Commit the changes to `Sources/ConcordiumWalletCrypto/crypto.swift` and `Package.swift`
+   (no other files should have changes)
+   and push an annotated tag named by the version for the new commit:
    ```shell
    git tag -a <version>
    ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,12 +12,12 @@ uniffi::include_scaffolding!("lib");
 /// Error type returned by the bridge functions.
 /// A corresponding Swift type will be generated (via the UDL definition).
 #[derive(Debug, thiserror::Error)]
-enum ConcordiumWalletCryptoError {
+pub enum ConcordiumWalletCryptoError {
     #[error("call {call} failed: {msg}")]
     CallFailed { call: String, msg: String },
 }
 
-fn get_account_signing_key(
+pub fn get_account_signing_key(
     seed_hex: String,
     net: String,
     identity_provider_index: u32,
@@ -31,7 +31,7 @@ fn get_account_signing_key(
         })
 }
 
-fn get_account_public_key(
+pub fn get_account_public_key(
     seed_hex: String,
     net: String,
     identity_provider_index: u32,
@@ -45,7 +45,7 @@ fn get_account_public_key(
         })
 }
 
-fn get_id_cred_sec(
+pub fn get_id_cred_sec(
     seed_hex: String,
     net: String,
     identity_provider_index: u32,
@@ -58,7 +58,7 @@ fn get_id_cred_sec(
         })
 }
 
-fn get_prf_key(
+pub fn get_prf_key(
     seed_hex: String,
     net: String,
     identity_provider_index: u32,
@@ -71,7 +71,7 @@ fn get_prf_key(
         })
 }
 
-fn get_credential_id(
+pub fn get_credential_id(
     seed_hex: String,
     net: String,
     identity_provider_index: u32,
@@ -86,7 +86,7 @@ fn get_credential_id(
         })
 }
 
-fn get_signature_blinding_randomness(
+pub fn get_signature_blinding_randomness(
     seed_hex: String,
     net: String,
     identity_provider_index: u32,
@@ -99,7 +99,7 @@ fn get_signature_blinding_randomness(
         })
 }
 
-fn get_attribute_commitment_randomness(
+pub fn get_attribute_commitment_randomness(
     seed_hex: String,
     net: String,
     identity_provider_index: u32,
@@ -114,7 +114,7 @@ fn get_attribute_commitment_randomness(
         })
 }
 
-fn get_verifiable_credential_signing_key(
+pub fn get_verifiable_credential_signing_key(
     seed_hex: String,
     net: String,
     issuer_index: u64,
@@ -128,7 +128,7 @@ fn get_verifiable_credential_signing_key(
         })
 }
 
-fn get_verifiable_credential_public_key(
+pub fn get_verifiable_credential_public_key(
     seed_hex: String,
     net: String,
     issuer_index: u64,
@@ -142,7 +142,7 @@ fn get_verifiable_credential_public_key(
         })
 }
 
-fn get_verifiable_credential_backup_encryption_key(
+pub fn get_verifiable_credential_backup_encryption_key(
     seed_hex: String,
     net: String,
 ) -> Result<String, ConcordiumWalletCryptoError> {
@@ -152,188 +152,4 @@ fn get_verifiable_credential_backup_encryption_key(
             msg: e.to_string(),
         }
     })
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    const SEED: &str = "efa5e27326f8fa0902e647b52449bf335b7b605adc387015ec903f41d95080eb71361cbc7fb78721dcd4f3926a337340aa1406df83332c44c1cdcfe100603860";
-    const MAINNET: &str = "mainnet";
-    const TESTNET: &str = "testnet";
-    const COMMITMENT_KEY: &str = "b14cbfe44a02c6b1f78711176d5f437295367aa4f2a8c2551ee10d25a03adc69d61a332a058971919dad7312e1fc94c5a8d45e64b6f917c540eee16c970c3d4b7f3caf48a7746284878e2ace21c82ea44bf84609834625be1f309988ac523fac";
-
-    // TODO: Add negative tests (there currently are none).
-
-    /* Tests ported from https://github.com/Concordium/concordium-swift-sdk/blob/5e700261a0dc08dd483981ce75c008d6bc3c80e5/Tests/ConcordiumSwiftSdkTests/ConcordiumHdWalletTest.swift
-     * such that we don't have to release in order to be able to run tests.
-     * The tests that verify that public keys match their sign counterparts have not been ported as that would require this crate to add dependencies that we otherwise don't need.
-     * And the property is covered by the fact that we test the exact generated keys anyway.
-     */
-
-    #[test]
-    fn mainnet_signing_key() {
-        assert_eq!(
-            get_account_signing_key(SEED.to_string(), MAINNET.to_string(), 0, 55, 7).unwrap(),
-            "e4d1693c86eb9438feb9cbc3d561fbd9299e3a8b3a676eb2483b135f8dbf6eb1"
-        )
-    }
-
-    #[test]
-    fn mainnet_public_key() {
-        assert_eq!(
-            get_account_public_key(SEED.to_string(), MAINNET.to_string(), 1, 341, 9).unwrap(),
-            "d54aab7218fc683cbd4d822f7c2b4e7406c41ae08913012fab0fa992fa008e98"
-        )
-    }
-
-    #[test]
-    fn mainnet_id_cred_sec() {
-        assert_eq!(
-            get_id_cred_sec(SEED.to_string(), MAINNET.to_string(), 2, 115).unwrap(),
-            "33b9d19b2496f59ed853eb93b9d374482d2e03dd0a12e7807929d6ee54781bb1"
-        )
-    }
-
-    #[test]
-    fn mainnet_prf_key() {
-        assert_eq!(
-            get_prf_key(SEED.to_string(), MAINNET.to_string(), 3, 35).unwrap(),
-            "4409e2e4acffeae641456b5f7406ecf3e1e8bd3472e2df67a9f1e8574f211bc5"
-        )
-    }
-
-    #[test]
-    fn mainnet_cred_id() {
-        assert_eq!(
-            get_credential_id(SEED.to_string(), MAINNET.to_string(), 10, 50, 5, COMMITMENT_KEY.to_string()).unwrap(),
-            "8a3a87f3f38a7a507d1e85dc02a92b8bcaa859f5cf56accb3c1bc7c40e1789b4933875a38dd4c0646ca3e940a02c42d8"
-        )
-    }
-
-    #[test]
-    fn mainnet_blinding_randomness() {
-        assert_eq!(
-            get_signature_blinding_randomness(SEED.to_string(), MAINNET.to_string(), 4, 5713)
-                .unwrap(),
-            "1e3633af2b1dbe5600becfea0324bae1f4fa29f90bdf419f6fba1ff520cb3167"
-        )
-    }
-
-    #[test]
-    fn mainnet_attribute_commitment_randomness() {
-        assert_eq!(
-            get_attribute_commitment_randomness(SEED.to_string(), MAINNET.to_string(), 5, 0, 4, 0)
-                .unwrap(),
-            "6ef6ba6490fa37cd517d2b89a12b77edf756f89df5e6f5597440630cd4580b8f"
-        )
-    }
-
-    #[test]
-    fn testnet_signing_key() {
-        assert_eq!(
-            get_account_signing_key(SEED.to_string(), TESTNET.to_string(), 0, 55, 7).unwrap(),
-            "aff97882c6df085e91ae2695a32d39dccb8f4b8d68d2f0db9637c3a95f845e3c"
-        )
-    }
-
-    #[test]
-    fn testnet_public_key() {
-        assert_eq!(
-            get_account_public_key(SEED.to_string(), TESTNET.to_string(), 1, 341, 9).unwrap(),
-            "ef6fd561ca0291a57cdfee896245db9803a86da74c9a6c1bf0252b18f8033003"
-        )
-    }
-
-    #[test]
-    fn testnet_id_cred_sec() {
-        assert_eq!(
-            get_id_cred_sec(SEED.to_string(), TESTNET.to_string(), 2, 115).unwrap(),
-            "33c9c538e362c5ac836afc08210f4b5d881ba65a0a45b7e353586dad0a0f56df"
-        )
-    }
-
-    #[test]
-    fn testnet_prf_key() {
-        assert_eq!(
-            get_prf_key(SEED.to_string(), TESTNET.to_string(), 3, 35).unwrap(),
-            "41d794d0b06a7a31fb79bb76c44e6b87c63e78f9afe8a772fc64d20f3d9e8e82"
-        )
-    }
-
-    #[test]
-    fn testnet_cred_id() {
-        assert_eq!(
-            get_credential_id(SEED.to_string(), TESTNET.to_string(), 10, 50, 5, COMMITMENT_KEY.to_string()).unwrap(),
-            "9535e4f2f964c955c1dd0f312f2edcbf4c7d036fe3052372a9ad949ff061b9b7ed6b00f93bc0713e381a93a43715206c"
-        )
-    }
-
-    #[test]
-    fn testnet_blinding_randomness() {
-        assert_eq!(
-            get_signature_blinding_randomness(SEED.to_string(), TESTNET.to_string(), 4, 5713)
-                .unwrap(),
-            "079eb7fe4a2e89007f411ede031543bd7f687d50341a5596e015c9f2f4c1f39b"
-        )
-    }
-
-    #[test]
-    fn testnet_attribute_commitment_randomness() {
-        assert_eq!(
-            get_attribute_commitment_randomness(SEED.to_string(), TESTNET.to_string(), 5, 0, 4, 0)
-                .unwrap(),
-            "409fa90314ec8fb4a2ae812fd77fe58bfac81765cad3990478ff7a73ba6d88ae"
-        )
-    }
-
-    #[test]
-    fn testnet_cred_id_matches_cred_deployment() {
-        assert_eq!(
-            get_credential_id(SEED.to_string(), TESTNET.to_string(), 0, 0, 1, COMMITMENT_KEY.to_string()).unwrap(),
-            "b317d3fea7de56f8c96f6e72820c5cd502cc0eef8454016ee548913255897c6b52156cc60df965d3efb3f160eff6ced4"
-        )
-    }
-
-    #[test]
-    fn mainnet_verifiable_credential_signing_key() {
-        assert_eq!(
-            get_verifiable_credential_signing_key(SEED.to_string(), MAINNET.to_string(), 1, 2, 1)
-                .unwrap(),
-            "670d904509ce09372deb784e702d4951d4e24437ad3879188d71ae6db51f3301"
-        )
-    }
-
-    #[test]
-    fn mainnet_verifiable_credential_public_key() {
-        assert_eq!(
-            get_verifiable_credential_public_key(
-                SEED.to_string(),
-                MAINNET.to_string(),
-                3,
-                1232,
-                341
-            )
-            .unwrap(),
-            "16afdb3cb3568b5ad8f9a0fa3c741b065642de8c53e58f7920bf449e63ff2bf9"
-        )
-    }
-
-    #[test]
-    fn testnet_verifiable_credential_signing_key() {
-        assert_eq!(
-            get_verifiable_credential_signing_key(SEED.to_string(), TESTNET.to_string(), 13, 0, 1)
-                .unwrap(),
-            "c75a161b97a1e204d9f31202308958e541e14f0b14903bd220df883bd06702bb"
-        )
-    }
-
-    #[test]
-    fn testnet_verifiable_credential_public_key() {
-        assert_eq!(
-            get_verifiable_credential_public_key(SEED.to_string(), TESTNET.to_string(), 17, 0, 341)
-                .unwrap(),
-            "c52a30475bac88da9e65471cf9cf59f99dcce22ce31de580b3066597746b394a"
-        )
-    }
 }

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -1,0 +1,172 @@
+use concordium_wallet_crypto_uniffi::*;
+
+const SEED: &str = "efa5e27326f8fa0902e647b52449bf335b7b605adc387015ec903f41d95080eb71361cbc7fb78721dcd4f3926a337340aa1406df83332c44c1cdcfe100603860";
+const MAINNET: &str = "mainnet";
+const TESTNET: &str = "testnet";
+const COMMITMENT_KEY: &str = "b14cbfe44a02c6b1f78711176d5f437295367aa4f2a8c2551ee10d25a03adc69d61a332a058971919dad7312e1fc94c5a8d45e64b6f917c540eee16c970c3d4b7f3caf48a7746284878e2ace21c82ea44bf84609834625be1f309988ac523fac";
+
+// TODO: Add negative tests (currently there are none).
+
+/* Tests ported from https://github.com/Concordium/concordium-swift-sdk/blob/5e700261a0dc08dd483981ce75c008d6bc3c80e5/Tests/ConcordiumSwiftSdkTests/ConcordiumHdWalletTest.swift
+ * such that we don't have to release in order to be able to run tests.
+ * The tests that verify that public keys match their sign counterparts have not been ported as that would require this crate to add dependencies that we otherwise don't need.
+ * And the property is covered by the fact that we test the exact generated keys anyway.
+ */
+
+#[test]
+fn mainnet_signing_key() {
+    assert_eq!(
+        get_account_signing_key(SEED.to_string(), MAINNET.to_string(), 0, 55, 7).unwrap(),
+        "e4d1693c86eb9438feb9cbc3d561fbd9299e3a8b3a676eb2483b135f8dbf6eb1"
+    );
+}
+
+#[test]
+fn mainnet_public_key() {
+    assert_eq!(
+        get_account_public_key(SEED.to_string(), MAINNET.to_string(), 1, 341, 9).unwrap(),
+        "d54aab7218fc683cbd4d822f7c2b4e7406c41ae08913012fab0fa992fa008e98"
+    );
+}
+
+#[test]
+fn mainnet_id_cred_sec() {
+    assert_eq!(
+        get_id_cred_sec(SEED.to_string(), MAINNET.to_string(), 2, 115).unwrap(),
+        "33b9d19b2496f59ed853eb93b9d374482d2e03dd0a12e7807929d6ee54781bb1"
+    );
+}
+
+#[test]
+fn mainnet_prf_key() {
+    assert_eq!(
+        get_prf_key(SEED.to_string(), MAINNET.to_string(), 3, 35).unwrap(),
+        "4409e2e4acffeae641456b5f7406ecf3e1e8bd3472e2df67a9f1e8574f211bc5"
+    );
+}
+
+#[test]
+fn mainnet_cred_id() {
+    assert_eq!(
+        get_credential_id(SEED.to_string(), MAINNET.to_string(), 10, 50, 5, COMMITMENT_KEY.to_string()).unwrap(),
+        "8a3a87f3f38a7a507d1e85dc02a92b8bcaa859f5cf56accb3c1bc7c40e1789b4933875a38dd4c0646ca3e940a02c42d8"
+    );
+}
+
+#[test]
+fn mainnet_blinding_randomness() {
+    assert_eq!(
+        get_signature_blinding_randomness(SEED.to_string(), MAINNET.to_string(), 4, 5713).unwrap(),
+        "1e3633af2b1dbe5600becfea0324bae1f4fa29f90bdf419f6fba1ff520cb3167"
+    );
+}
+
+#[test]
+fn mainnet_attribute_commitment_randomness() {
+    assert_eq!(
+        get_attribute_commitment_randomness(SEED.to_string(), MAINNET.to_string(), 5, 0, 4, 0)
+            .unwrap(),
+        "6ef6ba6490fa37cd517d2b89a12b77edf756f89df5e6f5597440630cd4580b8f"
+    );
+}
+
+#[test]
+fn testnet_signing_key() {
+    assert_eq!(
+        get_account_signing_key(SEED.to_string(), TESTNET.to_string(), 0, 55, 7).unwrap(),
+        "aff97882c6df085e91ae2695a32d39dccb8f4b8d68d2f0db9637c3a95f845e3c"
+    );
+}
+
+#[test]
+fn testnet_public_key() {
+    assert_eq!(
+        get_account_public_key(SEED.to_string(), TESTNET.to_string(), 1, 341, 9).unwrap(),
+        "ef6fd561ca0291a57cdfee896245db9803a86da74c9a6c1bf0252b18f8033003"
+    );
+}
+
+#[test]
+fn testnet_id_cred_sec() {
+    assert_eq!(
+        get_id_cred_sec(SEED.to_string(), TESTNET.to_string(), 2, 115).unwrap(),
+        "33c9c538e362c5ac836afc08210f4b5d881ba65a0a45b7e353586dad0a0f56df"
+    );
+}
+
+#[test]
+fn testnet_prf_key() {
+    assert_eq!(
+        get_prf_key(SEED.to_string(), TESTNET.to_string(), 3, 35).unwrap(),
+        "41d794d0b06a7a31fb79bb76c44e6b87c63e78f9afe8a772fc64d20f3d9e8e82"
+    );
+}
+
+#[test]
+fn testnet_cred_id() {
+    assert_eq!(
+        get_credential_id(SEED.to_string(), TESTNET.to_string(), 10, 50, 5, COMMITMENT_KEY.to_string()).unwrap(),
+        "9535e4f2f964c955c1dd0f312f2edcbf4c7d036fe3052372a9ad949ff061b9b7ed6b00f93bc0713e381a93a43715206c"
+    );
+}
+
+#[test]
+fn testnet_blinding_randomness() {
+    assert_eq!(
+        get_signature_blinding_randomness(SEED.to_string(), TESTNET.to_string(), 4, 5713).unwrap(),
+        "079eb7fe4a2e89007f411ede031543bd7f687d50341a5596e015c9f2f4c1f39b"
+    );
+}
+
+#[test]
+fn testnet_attribute_commitment_randomness() {
+    assert_eq!(
+        get_attribute_commitment_randomness(SEED.to_string(), TESTNET.to_string(), 5, 0, 4, 0)
+            .unwrap(),
+        "409fa90314ec8fb4a2ae812fd77fe58bfac81765cad3990478ff7a73ba6d88ae"
+    );
+}
+
+#[test]
+fn testnet_cred_id_matches_cred_deployment() {
+    assert_eq!(
+        get_credential_id(SEED.to_string(), TESTNET.to_string(), 0, 0, 1, COMMITMENT_KEY.to_string()).unwrap(),
+        "b317d3fea7de56f8c96f6e72820c5cd502cc0eef8454016ee548913255897c6b52156cc60df965d3efb3f160eff6ced4"
+    );
+}
+
+#[test]
+fn mainnet_verifiable_credential_signing_key() {
+    assert_eq!(
+        get_verifiable_credential_signing_key(SEED.to_string(), MAINNET.to_string(), 1, 2, 1)
+            .unwrap(),
+        "670d904509ce09372deb784e702d4951d4e24437ad3879188d71ae6db51f3301"
+    );
+}
+
+#[test]
+fn mainnet_verifiable_credential_public_key() {
+    assert_eq!(
+        get_verifiable_credential_public_key(SEED.to_string(), MAINNET.to_string(), 3, 1232, 341)
+            .unwrap(),
+        "16afdb3cb3568b5ad8f9a0fa3c741b065642de8c53e58f7920bf449e63ff2bf9"
+    );
+}
+
+#[test]
+fn testnet_verifiable_credential_signing_key() {
+    assert_eq!(
+        get_verifiable_credential_signing_key(SEED.to_string(), TESTNET.to_string(), 13, 0, 1)
+            .unwrap(),
+        "c75a161b97a1e204d9f31202308958e541e14f0b14903bd220df883bd06702bb"
+    );
+}
+
+#[test]
+fn testnet_verifiable_credential_public_key() {
+    assert_eq!(
+        get_verifiable_credential_public_key(SEED.to_string(), TESTNET.to_string(), 17, 0, 341)
+            .unwrap(),
+        "c52a30475bac88da9e65471cf9cf59f99dcce22ce31de580b3066597746b394a"
+    );
+}


### PR DESCRIPTION
A bunch of hideous tests are going to be added in an [upcoming PR](https://github.com/Concordium/concordium-wallet-crypto-swift/pull/6). Moving the test to their own file/module reduces the noise in the implementation file. The tests are entirely unmodified.

This separation is usually associated with integration tests in Rust. As the tests actually just exercise the exposed functions (which now actually have to be public), this seems appropriate.

It also seems appropriate in this regard to give the crate a less generic name than 'crypto'. It therefore is now named 'concordium-wallet-crypto-uniffi', reflecting that it should be able to target all languages supported by UniFFI, not just Swift (i.e. at least also Kotlin and Python). This has not been verified though.

Finally, the UniFFI dependency was bumped from v0.25.x to the latest version v0.26.x.