### PR TITLE
CI: Run tests on all platforms and verify build

### DIFF
--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check formatting
         run: cargo fmt --check
       - name: Run linter
-        run: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -Dwarnings
       - name: Run tests
         run: cargo test
       - name: Build Swift package (macOS/x86_64 only)

--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -37,3 +37,17 @@ jobs:
         run: cargo clippy
       - name: Run tests
         run: cargo test
+      - name: Build Swift package (macOS only)
+        if: runner.os == 'macOS'
+        run: |
+          # TODO: build for own platform only
+          rustup target add \
+            aarch64-apple-darwin \
+            aarch64-apple-ios \
+            aarch64-apple-ios-sim \
+            x86_64-apple-darwin \
+            x86_64-apple-ios
+          make framework
+          CONCORDIUM_WALLET_CRYPTO_FRAMEWORK_PATH=./generated/ConcordiumWalletCrypto.xcframework \
+            swift build
+          

--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -48,6 +48,6 @@ jobs:
             x86_64-apple-darwin \
             x86_64-apple-ios
           make framework
-          CONCORDIUM_WALLET_CRYPTO_FRAMEWORK_PATH=./generated/ConcordiumWalletCrypto.xcframework \
+          CONCORDIUM_WALLET_CRYPTO_FRAMEWORK_PATH=./generated/ConcordiumWalletCryptoUniffi.xcframework \
             swift build
           

--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -5,18 +5,20 @@ on:
     branches: main
   pull_request:
 
-env:
-  rust_version: "1.72"
-
 jobs:
   lint-and-test:
-    runs-on: macos-13
+    strategy:
+      matrix:
+        runner: [macos-13, ubuntu-latest, windows-latest]
+        rust-version: ["1.72"]
+
+    runs-on: "${{matrix.runner}}"
 
     steps:
       # TODO: Consider adding caching.
       - name: Setup Rust
         run: |
-          rustup default "${{env.rust_version}}"
+          rustup default "${{matrix.rust-version}}"
           rustup component add rustfmt clippy
       - name: Check out sources
         uses: actions/checkout@v4

--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -9,8 +9,15 @@ jobs:
   lint-and-test:
     strategy:
       matrix:
-        runner: [macos-13, ubuntu-latest, windows-latest]
-        rust-version: ["1.72"]
+        runner:
+          - macos-11
+          - macos-12
+          - macos-13
+          - macos-14
+          - ubuntu-latest
+          - windows-latest
+        rust-version:
+          - "1.72"
 
     runs-on: "${{matrix.runner}}"
 

--- a/.github/workflows/lint+test.yml
+++ b/.github/workflows/lint+test.yml
@@ -37,17 +37,23 @@ jobs:
         run: cargo clippy
       - name: Run tests
         run: cargo test
-      - name: Build Swift package (macOS only)
-        if: runner.os == 'macOS'
+      - name: Build Swift package (macOS/x86_64 only)
+        if: runner.os == 'macOS' && runner.arch == 'X64'
         run: |
-          # TODO: build for own platform only
-          rustup target add \
-            aarch64-apple-darwin \
-            aarch64-apple-ios \
-            aarch64-apple-ios-sim \
-            x86_64-apple-darwin \
-            x86_64-apple-ios
-          make framework
-          CONCORDIUM_WALLET_CRYPTO_FRAMEWORK_PATH=./generated/ConcordiumWalletCryptoUniffi.xcframework \
-            swift build
-          
+          make swift-bindings lib-darwin-x86_64 # produces './generated/bindings' and './target/x86_64-apple-darwin/release/libconcordium_wallet_crypto_uniffi.a'
+          xcodebuild -create-xcframework \
+            -library ./target/x86_64-apple-darwin/release/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
+            -output ./generated/ConcordiumWalletCryptoUniffi.xcframework
+      - name: Build Swift package (macOS/arm64 only)
+        if: runner.os == 'macOS' && runner.arch == 'ARM64'
+        run: |
+          make swift-bindings lib-darwin-aarch64 # produces './generated/bindings' and './target/aarch64-apple-darwin/release/libconcordium_wallet_crypto_uniffi.a'
+          xcodebuild -create-xcframework \
+            -library ./target/aarch64-apple-darwin/release/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
+            -output ./generated/ConcordiumWalletCryptoUniffi.xcframework
+      - name: Verify that library builds (macOS only)
+        if: runner.os == 'macOS'
+        run: swift build
+        env:
+          # Use the local framework built in previous step.
+          CONCORDIUM_WALLET_CRYPTO_FRAMEWORK_PATH: ./generated/ConcordiumWalletCryptoUniffi.xcframework

--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -17,14 +17,7 @@ jobs:
 
     steps:
       - name: Setup Rust
-        run: |
-          rustup default "${{env.rust_version}}"
-          rustup target add \
-            aarch64-apple-darwin \
-            aarch64-apple-ios \
-            aarch64-apple-ios-sim \
-            x86_64-apple-darwin \
-            x86_64-apple-ios
+        run: make setup
       - name: Check out sources
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -30,17 +30,17 @@ jobs:
         with:
           submodules: recursive
       - name: Build binary framework
-        run: make framework # produces './generated/ConcordiumWalletCrypto.xcframework'
+        run: make framework # produces './generated/ConcordiumWalletCryptoUniffi.xcframework'
       - name: Archive framework
         working-directory: ./generated
         run: |
-          zip -r ./ConcordiumWalletCrypto.xcframework.zip ./ConcordiumWalletCrypto.xcframework
-          swift package compute-checksum ./ConcordiumWalletCrypto.xcframework.zip > ./CHECKSUM
+          zip -r ./ConcordiumWalletCryptoUniffi.xcframework.zip ./ConcordiumWalletCryptoUniffi.xcframework
+          swift package compute-checksum ./ConcordiumWalletCryptoUniffi.xcframework.zip > ./CHECKSUM
       - name: Upload package as GitHub release
         uses: softprops/action-gh-release@v1
         with:
             files: |
-              ./generated/ConcordiumWalletCrypto.xcframework.zip
+              ./generated/ConcordiumWalletCryptoUniffi.xcframework.zip
               ./generated/CHECKSUM
             name: '${{github.event.inputs.version}}'
             generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Rename crate from "crypto" to "concordium-wallet-crypto-uniffi"
-- Rename generated framework from "RustFramework" to "ConcordiumWalletCrypto".
+- Rename crate from "crypto" to "concordium-wallet-crypto-uniffi" and verify on CI that project works on all platforms.
+- Rename generated framework from "RustFramework" to "ConcordiumWalletCryptoUniffi".
+- Ensure that library builds on macOS 11+ and verify on CI.
 - Bump UniFFI from v0.25.x to v0.26.x.
 
 ## [1.0.0] - 2024-02-06

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ setup:
 
 # BUILD FRAMEWORK #
 
-.PHONY: framework # produces './generated/ConcordiumWalletCrypto.xcframework'
+.PHONY: framework # produces './generated/ConcordiumWalletCryptoUniffi.xcframework'
 framework: clean-generated swift-bindings lib-darwin lib-ios lib-ios-sim
 	xcodebuild -create-xcframework \
 	  -library ./generated/target/universal-darwin/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
 	  -library ./target/aarch64-apple-ios/release/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
 	  -library ./generated/target/universal-ios/libconcordium_wallet_crypto_uniffi.a -headers ./generated/bindings \
-	  -output ./generated/ConcordiumWalletCrypto.xcframework
+	  -output ./generated/ConcordiumWalletCryptoUniffi.xcframework
 
 # GENERATE BINDINGS #
 

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.6
+// swift-tools-version: 5.5
 
 import Foundation
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -17,14 +17,14 @@ let package = Package(
     ],
     targets: [
         overridableFrameworkTarget(
-            name: "ConcordiumWalletCryptoFramework",
+            name: "ConcordiumWalletCryptoUniffi",
             url: "https://github.com/Concordium/concordium-wallet-crypto-swift/releases/download/build%2F1.0.0-1/RustFramework.xcframework.zip",
             checksum: "edc2628d1721697b555891316dac3be1490072c1649d040fff8f3c160b2d0e09"
         ),
         .target(
             name: "ConcordiumWalletCrypto",
             dependencies: [
-                .target(name: "ConcordiumWalletCryptoFramework"),
+                .target(name: "ConcordiumWalletCryptoUniffi"),
             ]
         ),
     ]
@@ -42,7 +42,7 @@ func providedFrameworkPath() -> String? {
         return p
     }
     if let _ = getEnv("CONCORDIUM_WALLET_CRYPTO_PATH") {
-        return "./generated/ConcordiumWalletCrypto.xcframework"
+        return "./generated/ConcordiumWalletCryptoUniffi.xcframework"
     }
     return nil
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 5.6
 
+import Foundation
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Run
 make framework
 ```
 
-This script will compile the sources into a framework `./generated/ConcordiumWalletCrypto.xcframework`
+This script will compile the sources into a framework `./generated/ConcordiumWalletCryptoUniffi.xcframework`
 that supports the following platforms:
 
 - macOS: x86_64 (`x86_64-apple-darwin`) and ARM (`aarch64-apple-darwin`) as a universal binary
@@ -94,7 +94,7 @@ the provided path is evaluated relative to the root of this project.
 
 For convenience, if `CONCORDIUM_WALLET_CRYPTO_PATH` is set
 (indicating that we're using a development version of this library)
-then `CONCORDIUM_WALLET_CRYPTO_FRAMEWORK_PATH` will default to `./generated/ConcordiumWalletCrypto.xcframework`.
+then `CONCORDIUM_WALLET_CRYPTO_FRAMEWORK_PATH` will default to `./generated/ConcordiumWalletCryptoUniffi.xcframework`.
 Provide the empty string to that variable to disable this behavior.
 
 ### Rust


### PR DESCRIPTION
This library is not Mac/iThing specific. UniFFI supports other languages that work on all platforms. Furthermore, Swift actually supports Linux and we might want the SDK to support that platform one day.

It therefore seems reasonable to avoid unknowingly adding anything that breaks multiplatform support in this library. Hence we should also test the Rust code on Ubuntu and Windows.

We also run on all available macOS runners, including building the actual Swift package, to gain assurance that older versions work as well. With this, we found that a few changes were required for supporting older versions of Swift (back to the version running on the oldest Mac-based GitHub Actions runner `macos-11`, which is an Intel Mac):

- Explicitly import `Foundation` in `Package.swift` for using `ProcessInfo` (for reading env vars).
- Downgrade `swift-tools-version` to v5.5 in `Package.swift`.
- Renamed to `ConcordiumWalletCryptoUniffi.xcframework` to match the (similarly renamed) binary target in `Package.swift`. We cannot just rename the target to match the existing generated file because that name (`ConcordiumWalletCrypto`) is already used by the library product target.

To avoid wasting resources and also speed up verification of the Swift package itself, we only build the framework for the runner platform, not the full multi-platform bundle produced by `make framework`.