### PR TITLE
Bump version for release

### DIFF
--- a/.github/workflows/publish-framework.yml
+++ b/.github/workflows/publish-framework.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: macos-13
 
     steps:
-      - name: Setup Rust
-        run: make setup
       - name: Check out sources
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Setup Rust
+        run: make setup
       - name: Build binary framework
         run: make framework # produces './generated/ConcordiumWalletCryptoUniffi.xcframework'
       - name: Archive framework

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2024-03-20
+
 ### Added
 
 - Build-time environment variable `CONCORDIUM_WALLET_CRYPTO_FRAMEWORK_PATH`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wallet-crypto-uniffi"
-version = "1.0.0"
+version = "2.0.0"
 dependencies = [
  "concordium_base",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-wallet-crypto-uniffi"
-version = "1.0.0"
+version = "2.0.0"
 edition = "2021"
 
 [lib]

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         overridableFrameworkTarget(
             name: "ConcordiumWalletCryptoUniffi",
-            url: "https://github.com/Concordium/concordium-wallet-crypto-swift/releases/download/build%2F1.0.0-1/RustFramework.xcframework.zip",
-            checksum: "edc2628d1721697b555891316dac3be1490072c1649d040fff8f3c160b2d0e09"
+            url: "https://github.com/Concordium/concordium-wallet-crypto-swift/releases/download/build%2F2.0.0-1/ConcordiumWalletCryptoUniffi.xcframework.zip",
+            checksum: "b1843de4d15f29567d8bf59a5be090168356d94925b467fe5e8b592be7df56ef"
         ),
         .target(
             name: "ConcordiumWalletCrypto",


### PR DESCRIPTION
Bump the version of the Cargo project, regenerate Swift bindings, and update the package spec to point to the binary framework built from the updated Cargo project.

This follows the release process described [here](https://github.com/Concordium/concordium-wallet-crypto-swift/blob/3f09508b9e34c935c0b236668b4f4ec4fc41a4a3/README.md#release-new-version).