### PR TITLE
Fix type of AR threshold and rename parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `ChoiceArParameter` field `threshold`: Change type from `u32` to `u8` as that's the proper type.
+- Rename `identity_provider_index` to `identity_provider_id` in UDL definition for consistency with SDK.
+
 ## [2.0.0] - 2024-03-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Changed/fixed
 
 - `ChoiceArParameter` field `threshold`: Change type from `u32` to `u8` as that's the proper type.
 - Rename `identity_provider_index` to `identity_provider_id` in UDL definition for consistency with SDK.
+- `ChainArData` field `end_id_cred_pub_share_hex`: Renamed to `enc_id_cred_pub_share_hex` to fix typo.
 
 ## [2.0.0] - 2024-03-20
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [Swift package](https://developer.apple.com/documentation/xcode/swift-packages) providing bindings for Swift
 of Concordium specific cryptographic functions that are written in Rust.
 
-The project is a core component of [`ConcordiumSwiftSdk`](https://github.com/Concordium/concordium-swift-sdk.git).
+The project is a core component of the [Concordium Swift SDK](https://github.com/Concordium/concordium-swift-sdk.git).
 It has its own repository because of limitations in SwiftPM
 that prevent us from publishing everything in a single complete package.
 In brief, Swift packages must be downloaded straight from git,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,12 +35,12 @@ pub enum ConcordiumWalletCryptoError {
 pub fn identity_cred_sec_hex(
     seed_hex: String,
     net: String,
-    identity_provider_index: u32,
+    identity_provider_id: u32,
     identity_index: u32,
 ) -> Result<String, ConcordiumWalletCryptoError> {
-    get_id_cred_sec_aux(seed_hex, net.as_str(), identity_provider_index, identity_index)
+    get_id_cred_sec_aux(seed_hex, net.as_str(), identity_provider_id, identity_index)
         .map_err(|e| ConcordiumWalletCryptoError::CallFailed {
-            call: format!("identity_cred_sec_hex(seed_hex, net={net}, identity_provider_index={identity_provider_index}, identity_index={identity_index})"),
+            call: format!("identity_cred_sec_hex(seed_hex, net={net}, identity_provider_id={identity_provider_id}, identity_index={identity_index})"),
             msg: format!("{:#}", e),
         })
 }
@@ -49,12 +49,12 @@ pub fn identity_cred_sec_hex(
 pub fn identity_prf_key_hex(
     seed_hex: String,
     net: String,
-    identity_provider_index: u32,
+    identity_provider_id: u32,
     identity_index: u32,
 ) -> Result<String, ConcordiumWalletCryptoError> {
-    get_prf_key_aux(seed_hex, net.as_str(), identity_provider_index, identity_index)
+    get_prf_key_aux(seed_hex, net.as_str(), identity_provider_id, identity_index)
         .map_err(|e| ConcordiumWalletCryptoError::CallFailed {
-            call: format!("identity_prf_key_hex(seed_hex, net={net}, identity_provider_index={identity_provider_index}, identity_index={identity_index})"),
+            call: format!("identity_prf_key_hex(seed_hex, net={net}, identity_provider_id={identity_provider_id}, identity_index={identity_index})"),
             msg: format!("{:#}", e),
         })
 }
@@ -63,12 +63,12 @@ pub fn identity_prf_key_hex(
 pub fn identity_attributes_signature_blinding_randomness_hex(
     seed_hex: String,
     net: String,
-    identity_provider_index: u32,
+    identity_provider_id: u32,
     identity_index: u32,
 ) -> Result<String, ConcordiumWalletCryptoError> {
-    get_signature_blinding_randomness_aux(seed_hex, net.as_str(), identity_provider_index, identity_index)
+    get_signature_blinding_randomness_aux(seed_hex, net.as_str(), identity_provider_id, identity_index)
         .map_err(|e| ConcordiumWalletCryptoError::CallFailed {
-            call: format!("identity_attributes_signature_blinding_randomness_hex(seed_hex, net={net}, identity_provider_index={identity_provider_index}, identity_index={identity_index})"),
+            call: format!("identity_attributes_signature_blinding_randomness_hex(seed_hex, net={net}, identity_provider_id={identity_provider_id}, identity_index={identity_index})"),
             msg: format!("{:#}", e),
         })
 }
@@ -77,13 +77,13 @@ pub fn identity_attributes_signature_blinding_randomness_hex(
 pub fn account_credential_signing_key_hex(
     seed_hex: String,
     net: String,
-    identity_provider_index: u32,
+    identity_provider_id: u32,
     identity_index: u32,
     credential_counter: u8,
 ) -> Result<String, ConcordiumWalletCryptoError> {
-    get_account_signing_key_aux(seed_hex, net.as_str(), identity_provider_index, identity_index, credential_counter.into())
+    get_account_signing_key_aux(seed_hex, net.as_str(), identity_provider_id, identity_index, credential_counter.into())
         .map_err(|e| ConcordiumWalletCryptoError::CallFailed {
-            call: format!("account_credential_signing_key_hex(seed_hex, net={net}, identity_provider_index={identity_provider_index}, identity_index={identity_index}, credential_counter={credential_counter})"),
+            call: format!("account_credential_signing_key_hex(seed_hex, net={net}, identity_provider_id={identity_provider_id}, identity_index={identity_index}, credential_counter={credential_counter})"),
             msg: format!("{:#}", e),
         })
 }
@@ -92,13 +92,13 @@ pub fn account_credential_signing_key_hex(
 pub fn account_credential_public_key_hex(
     seed_hex: String,
     net: String,
-    identity_provider_index: u32,
+    identity_provider_id: u32,
     identity_index: u32,
     credential_counter: u8,
 ) -> Result<String, ConcordiumWalletCryptoError> {
-    get_account_public_key_aux(seed_hex, net.as_str(), identity_provider_index, identity_index, credential_counter.into())
+    get_account_public_key_aux(seed_hex, net.as_str(), identity_provider_id, identity_index, credential_counter.into())
         .map_err(|e| ConcordiumWalletCryptoError::CallFailed {
-            call: format!("account_credential_public_key_hex(seed_hex, net={net}, identity_provider_index={identity_provider_index}, identity_index={identity_index}, credential_counter={credential_counter})"),
+            call: format!("account_credential_public_key_hex(seed_hex, net={net}, identity_provider_id={identity_provider_id}, identity_index={identity_index}, credential_counter={credential_counter})"),
             msg: format!("{:#}", e),
         })
 }
@@ -107,14 +107,14 @@ pub fn account_credential_public_key_hex(
 pub fn account_credential_id_hex(
     seed_hex: String,
     net: String,
-    identity_provider_index: u32,
+    identity_provider_id: u32,
     identity_index: u32,
     credential_counter: u8,
     commitment_key: String,
 ) -> Result<String, ConcordiumWalletCryptoError> {
-    get_credential_id_aux(seed_hex, net.as_str(), identity_provider_index, identity_index, credential_counter, commitment_key.as_str())
+    get_credential_id_aux(seed_hex, net.as_str(), identity_provider_id, identity_index, credential_counter, commitment_key.as_str())
         .map_err(|e| ConcordiumWalletCryptoError::CallFailed {
-            call: format!("account_credential_id_hex(seed_hex, net={net}, identity_provider_index={identity_provider_index}, identity_index={identity_index}, credential_counter={credential_counter}, commitment_key={commitment_key})"),
+            call: format!("account_credential_id_hex(seed_hex, net={net}, identity_provider_id={identity_provider_id}, identity_index={identity_index}, credential_counter={credential_counter}, commitment_key={commitment_key})"),
             msg: format!("{:#}", e),
         })
 }
@@ -123,14 +123,14 @@ pub fn account_credential_id_hex(
 pub fn account_credential_attribute_commitment_randomness_hex(
     seed_hex: String,
     net: String,
-    identity_provider_index: u32,
+    identity_provider_id: u32,
     identity_index: u32,
     credential_counter: u8,
     attribute: u8,
 ) -> Result<String, ConcordiumWalletCryptoError> {
-    get_attribute_commitment_randomness_aux(seed_hex, net.as_str(), identity_provider_index, identity_index, credential_counter.into(), attribute)
+    get_attribute_commitment_randomness_aux(seed_hex, net.as_str(), identity_provider_id, identity_index, credential_counter.into(), attribute)
         .map_err(|e| ConcordiumWalletCryptoError::CallFailed {
-            call: format!("account_credential_attribute_commitment_randomness_hex(seed_hex, net={net}, identity_provider_index={identity_provider_index}, identity_index={identity_index}, credential_counter={credential_counter}, attribute={attribute})"),
+            call: format!("account_credential_attribute_commitment_randomness_hex(seed_hex, net={net}, identity_provider_id={identity_provider_id}, identity_index={identity_index}, credential_counter={credential_counter}, attribute={attribute})"),
             msg: format!("{:#}", e),
         })
 }
@@ -339,7 +339,7 @@ pub struct ChoiceArParameters {
     #[serde(rename = "arIdentities")]
     pub ar_identities: Vec<u32>,
     #[serde(rename = "threshold")]
-    pub threshold: u32,
+    pub threshold: u8,
 }
 
 /// UniFFI compatible bridge to [`concordium_base::id::types::IpArData<concordium_base::id::constants::ArCurve>`],

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -487,7 +487,7 @@ pub struct AccountCredential {
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ChainArData {
     #[serde(rename = "encIdCredPubShare")]
-    pub end_id_cred_pub_share_hex: String,
+    pub enc_id_cred_pub_share_hex: String,
 }
 
 /// UniFFI compatible bridge to [`concordium_base::id::types::Policy<concordium_base::id::constants::ArCurve,concordium_base::id::constants::AttributeKind> `],

--- a/src/lib.udl
+++ b/src/lib.udl
@@ -111,7 +111,7 @@ dictionary PreIdentityObject {
 /// Choice of anonymity revocation parameters.
 dictionary ChoiceArParameters {
     sequence<u32> ar_identities;
-    u32 threshold;
+    u8 threshold;
 };
 
 /// The data relating to a single anonymity revoker
@@ -250,43 +250,43 @@ namespace crypto {
     /// Supported values for `network`: "Testnet", "Mainnet".
     /// The result is hex encoded.
     [Throws=ConcordiumWalletCryptoError]
-    string identity_cred_sec_hex(string seed_hex, string network, u32 identity_provider_index, u32 identity_index);
+    string identity_cred_sec_hex(string seed_hex, string network, u32 identity_provider_id, u32 identity_index);
 
     /// Compute the PRF-key for the provided seed and identity indexes.
     /// Supported values for `network`: "Testnet", "Mainnet".
     /// The result is hex encoded.
     [Throws=ConcordiumWalletCryptoError]
-    string identity_prf_key_hex(string seed_hex, string network, u32 identity_provider_index, u32 identity_index);
+    string identity_prf_key_hex(string seed_hex, string network, u32 identity_provider_id, u32 identity_index);
 
     /// Compute the signature blinding randomness for the provided seed and identity indexes.
     /// Supported values for `network`: "Testnet", "Mainnet".
     /// The result is hex encoded.
     [Throws=ConcordiumWalletCryptoError]
-    string identity_attributes_signature_blinding_randomness_hex(string seed_hex, string network, u32 identity_provider_index, u32 identity_index);
+    string identity_attributes_signature_blinding_randomness_hex(string seed_hex, string network, u32 identity_provider_id, u32 identity_index);
 
     /// Compute the account credential signing key for the provided seed, identity indexes, and credential counter.
     /// Supported values for `network`: "Testnet", "Mainnet".
     /// The result is hex encoded.
     [Throws=ConcordiumWalletCryptoError]
-    string account_credential_signing_key_hex(string seed_hex, string network, u32 identity_provider_index, u32 identity_index, u8 credential_counter);
+    string account_credential_signing_key_hex(string seed_hex, string network, u32 identity_provider_id, u32 identity_index, u8 credential_counter);
 
     /// Compute the account credential public key for the provided seed, identity indexes, and credential counter.
     /// Supported values for `network`: "Testnet", "Mainnet".
     /// The result is hex encoded.
     [Throws=ConcordiumWalletCryptoError]
-    string account_credential_public_key_hex(string seed_hex, string network, u32 identity_provider_index, u32 identity_index, u8 credential_counter);
+    string account_credential_public_key_hex(string seed_hex, string network, u32 identity_provider_id, u32 identity_index, u8 credential_counter);
 
     /// Compute the credential ID for the provided seed, identity indexes, credential counter, and the chain's commitment key.
     /// Supported values for `network`: "Testnet", "Mainnet".
     /// The result is hex encoded.
     [Throws=ConcordiumWalletCryptoError]
-    string account_credential_id_hex(string seed_hex, string network, u32 identity_provider_index, u32 identity_index, u8 credential_counter, string commitment_key);
+    string account_credential_id_hex(string seed_hex, string network, u32 identity_provider_id, u32 identity_index, u8 credential_counter, string commitment_key);
 
     /// Compute the attribute commitment randomness for the provided seed, identity indexes, credential counter, and attribute number.
     /// Supported values for `network`: "Testnet", "Mainnet".
     /// The result is hex encoded.
     [Throws=ConcordiumWalletCryptoError]
-    string account_credential_attribute_commitment_randomness_hex(string seed_hex, string network, u32 identity_provider_index, u32 identity_index, u8 credential_counter, u8 attribute);
+    string account_credential_attribute_commitment_randomness_hex(string seed_hex, string network, u32 identity_provider_id, u32 identity_index, u8 credential_counter, u8 attribute);
 
     /// Compute the signing key for the provided seed, issuer indexes, and verifiable credential index.
     /// Supported values for `network`: "Testnet", "Mainnet".

--- a/src/lib.udl
+++ b/src/lib.udl
@@ -194,7 +194,7 @@ dictionary AccountCredential {
 /// Data relating to a single anonymity revoker constructed by the account holder.
 /// Typically a vector of these will be sent to the chain.
 dictionary ChainArData {
-    string end_id_cred_pub_share_hex;
+    string enc_id_cred_pub_share_hex;
 };
 
 /// Public credential keys currently on the account.

--- a/tests/lib_test.rs
+++ b/tests/lib_test.rs
@@ -486,13 +486,13 @@ fn account_credential_deployment_hash() {
     let input = AccountCredential {
             ar_data: HashMap::from([
                 (3, ChainArData {
-                    end_id_cred_pub_share_hex: "8af70ed13186d7c332bb894725c99ba9e58405a668cb3c9c48d6e85029284d29a91d8da59dacd0d85c925659426e198396c3f73e791ccec217bc92fbdc618877544b9a2789b4ea89d4cdcceb7df4cdde64284b400374585a59596543ae6c45d6".to_string(),
+                    enc_id_cred_pub_share_hex: "8af70ed13186d7c332bb894725c99ba9e58405a668cb3c9c48d6e85029284d29a91d8da59dacd0d85c925659426e198396c3f73e791ccec217bc92fbdc618877544b9a2789b4ea89d4cdcceb7df4cdde64284b400374585a59596543ae6c45d6".to_string(),
                 }),
                 (2, ChainArData {
-                    end_id_cred_pub_share_hex: "994686187e9568e1076a6a711068dae4bd663f6ca2886fb3f97254ff0cc4e9b17797fd2a19237d8ca94941b697a3d7308b9a8e1a12f3eb856d52d3bb3adc016ba8c8eacbe93339a920f436de86f66ed847a1b03aab3645c1635d956b723442c8".to_string(),
+                    enc_id_cred_pub_share_hex: "994686187e9568e1076a6a711068dae4bd663f6ca2886fb3f97254ff0cc4e9b17797fd2a19237d8ca94941b697a3d7308b9a8e1a12f3eb856d52d3bb3adc016ba8c8eacbe93339a920f436de86f66ed847a1b03aab3645c1635d956b723442c8".to_string(),
                 }),
                 (1, ChainArData {
-                    end_id_cred_pub_share_hex: "a52beef5e3c6491fce7012a268ee5b3ed03aeecdb496abd979bcc60803d6d3c970112599d500690c2f447daefb81223d99de5fd822fdfb7ce4c9fe7253995c639f9037ad64a529393ea5cc7db18b74432469208e0076a80ed2c22f7848b82895".to_string(),
+                    enc_id_cred_pub_share_hex: "a52beef5e3c6491fce7012a268ee5b3ed03aeecdb496abd979bcc60803d6d3c970112599d500690c2f447daefb81223d99de5fd822fdfb7ce4c9fe7253995c639f9037ad64a529393ea5cc7db18b74432469208e0076a80ed2c22f7848b82895".to_string(),
                 }),
             ]),
             cred_id_hex: "a9e510d6685f81c2d7f8a0177222d067982cc73699c5a7d64a80d06543797e808e04c52ea393ee300f50d5b4c6e87c57".to_string(),
@@ -540,13 +540,13 @@ fn account_credential_deployment_signed_payload() {
             credential: AccountCredential {
                 ar_data: HashMap::from([
                     (3, ChainArData {
-                        end_id_cred_pub_share_hex: "8af70ed13186d7c332bb894725c99ba9e58405a668cb3c9c48d6e85029284d29a91d8da59dacd0d85c925659426e198396c3f73e791ccec217bc92fbdc618877544b9a2789b4ea89d4cdcceb7df4cdde64284b400374585a59596543ae6c45d6".to_string(),
+                        enc_id_cred_pub_share_hex: "8af70ed13186d7c332bb894725c99ba9e58405a668cb3c9c48d6e85029284d29a91d8da59dacd0d85c925659426e198396c3f73e791ccec217bc92fbdc618877544b9a2789b4ea89d4cdcceb7df4cdde64284b400374585a59596543ae6c45d6".to_string(),
                     }),
                     (2, ChainArData {
-                        end_id_cred_pub_share_hex: "994686187e9568e1076a6a711068dae4bd663f6ca2886fb3f97254ff0cc4e9b17797fd2a19237d8ca94941b697a3d7308b9a8e1a12f3eb856d52d3bb3adc016ba8c8eacbe93339a920f436de86f66ed847a1b03aab3645c1635d956b723442c8".to_string(),
+                        enc_id_cred_pub_share_hex: "994686187e9568e1076a6a711068dae4bd663f6ca2886fb3f97254ff0cc4e9b17797fd2a19237d8ca94941b697a3d7308b9a8e1a12f3eb856d52d3bb3adc016ba8c8eacbe93339a920f436de86f66ed847a1b03aab3645c1635d956b723442c8".to_string(),
                     }),
                     (1, ChainArData {
-                        end_id_cred_pub_share_hex: "a52beef5e3c6491fce7012a268ee5b3ed03aeecdb496abd979bcc60803d6d3c970112599d500690c2f447daefb81223d99de5fd822fdfb7ce4c9fe7253995c639f9037ad64a529393ea5cc7db18b74432469208e0076a80ed2c22f7848b82895".to_string(),
+                        enc_id_cred_pub_share_hex: "a52beef5e3c6491fce7012a268ee5b3ed03aeecdb496abd979bcc60803d6d3c970112599d500690c2f447daefb81223d99de5fd822fdfb7ce4c9fe7253995c639f9037ad64a529393ea5cc7db18b74432469208e0076a80ed2c22f7848b82895".to_string(),
                     }),
                 ]),
                 cred_id_hex: "a9e510d6685f81c2d7f8a0177222d067982cc73699c5a7d64a80d06543797e808e04c52ea393ee300f50d5b4c6e87c57".to_string(),


### PR DESCRIPTION
It was noticed on the SDK side that the type of the field `threshold` of `ChoiceArParameters` was supposed to be `u8` but was in fact `u32`.

Also on the SDK side we consistently use the name "ID" for the IP's identifier, not index. We're correcting that here for consistency.