### PR TITLE
CI: Fix release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,12 +26,12 @@ jobs:
       with:
         version: |
           $(cargo metadata --format-version=1 2>/dev/null | jq -r '.packages[] | select(.name == "concordium-wallet-crypto-uniffi") | .version')
-    - name: 'Debug outputs'
+    - name: 'Print outputs (for debugging)'
       run: |
-        echo "${{github.ref}}"
-        echo "${{steps.ref.outputs.ref}}"
-        echo "${{steps.ref.outputs.ref-name}}"
-        echo "${{steps.crate-version.outputs.version}}"
+        echo "github.ref='${{github.ref}}'"
+        echo "steps.ref.outputs.ref='${{steps.ref.outputs.ref}}'"
+        echo "steps.ref.outputs.ref-name='${{steps.ref.outputs.ref-name}}'"
+        echo "steps.crate-version.outputs.version='${{steps.crate-version.outputs.version}}'"
     - name: Fail if tag doesn't match crate version
       if: "steps.crate-version.outputs.version != steps.ref.outputs.ref-name"
       run: exit 1

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -19,6 +19,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         ref: '${{steps.ref.outputs.ref}}'
+        submodules: recursive # necessary to call 'cargo metadata'
     - name: Extract version of the crate
       uses: bisgardo/github-action-echo@v1
       id: crate-version

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -25,7 +25,7 @@ jobs:
       id: crate-version
       with:
         version: |
-          $(cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "concordium-wallet-crypto-uniffi") | .version')
+          $(cargo metadata --format-version=1 2>/dev/null | jq -r '.packages[] | select(.name == "concordium-wallet-crypto-uniffi") | .version')
     - name: 'Debug outputs'
       run: |
         echo "${{github.ref}}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -10,32 +10,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Parse ref
+      uses: bisgardo/github-action-parse-ref@v1
+      id: ref
+      with:
+        ref: '${{github.ref}}'
     - name: Checkout project
       uses: actions/checkout@v4
       with:
-        ref: '${{github.ref}}'
+        ref: '${{steps.ref.outputs.ref}}'
     - name: Extract version of the crate
       uses: bisgardo/github-action-echo@v1
       id: crate-version
       with:
         version: |
           $(cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "concordium-wallet-crypto-uniffi") | .version')
+    - name: 'Debug outputs'
+      run: |
+        echo ${{github.ref}}
+        echo ${{steps.ref.outputs.ref}}
+        echo ${{steps.ref.outputs.ref-name}}
+        echo ${{steps.crate-version.outputs.version}}
     - name: Fail if tag doesn't match crate version
-      if: "steps.crate-version.version != github.ref"
+      if: "steps.crate-version.outputs.version != steps.ref.outputs.ref-name"
       run: exit 1
     - name: Extract tag message
       uses: bisgardo/github-action-echo@v1
       id: tag-msg
       with:
-        msg: '$(git for-each-ref "${{github.ref}}" --format="%(contents)")'
+        msg: '$(git for-each-ref "${{steps.ref.outputs.ref}}" --format="%(contents)")'
     - name: Fail if tag is not "annotated" or its message is empty
       if: "steps.tag-msg.outputs.msg == ''"
       run: exit 1
     - name: Upload package as GitHub release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: '${{github.ref}}'
-        name: '${{github.ref}}'
+        tag_name: '${{steps.ref.outputs.ref-name}}'
+        name: '${{steps.ref.outputs.ref-name}}'
         # Release body is the message of the annotated tag.
         body: |
           ${{steps.tag-msg.outputs.msg}}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,10 +27,10 @@ jobs:
           $(cargo metadata --format-version=1 | jq -r '.packages[] | select(.name == "concordium-wallet-crypto-uniffi") | .version')
     - name: 'Debug outputs'
       run: |
-        echo ${{github.ref}}
-        echo ${{steps.ref.outputs.ref}}
-        echo ${{steps.ref.outputs.ref-name}}
-        echo ${{steps.crate-version.outputs.version}}
+        echo "${{github.ref}}"
+        echo "${{steps.ref.outputs.ref}}"
+        echo "${{steps.ref.outputs.ref-name}}"
+        echo "${{steps.crate-version.outputs.version}}"
     - name: Fail if tag doesn't match crate version
       if: "steps.crate-version.outputs.version != steps.ref.outputs.ref-name"
       run: exit 1


### PR DESCRIPTION
The workflow (added in #12) erronously uses `github.ref` as the version name, but that value includes a `ref/tags/` prefix that should be removed. Added a step for doing that and ensured that the correct value is used.

Also needed to add submodule checkout for `cargo metadata` to work as well as throwing away logging output on stderr.

It was expected that there could be issues with this workflow becuse it couldn't be tested in advance. It's better tested now, but we still need a full successful run on `main` to be sure.