### PR TITLE
CI: Prevent addition of newline

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,7 +24,7 @@ jobs:
       uses: bisgardo/github-action-echo@v1
       id: crate-version
       with:
-        version: >
+        version: |-
           $(cargo metadata --format-version=1 2>/dev/null | jq -r '.packages[] | select(.name == "concordium-wallet-crypto-uniffi") | .version')
     - name: 'Print outputs (for debugging)'
       run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -24,7 +24,7 @@ jobs:
       uses: bisgardo/github-action-echo@v1
       id: crate-version
       with:
-        version: |
+        version: >
           $(cargo metadata --format-version=1 2>/dev/null | jq -r '.packages[] | select(.name == "concordium-wallet-crypto-uniffi") | .version')
     - name: 'Print outputs (for debugging)'
       run: |


### PR DESCRIPTION
Due to the way yaml multiline strings work, a newline gets included in the output value. This messes up the subsequent comparison.