### PR TITLE
release 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.1] - 2026-01-30
+- Replaced JSON map conversion for `ArInfos` with explicit `ArIdentity` + `ArInfo` mapping.
+- Added explicit `LabeledContextProperty` conversion to base format with clearer errors.
+- Improved error messages in `create_verifiable_presentation_v1` to pinpoint conversion failures.
+
 ## [5.1.0] - 2026-01-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -567,7 +567,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-wallet-crypto-uniffi"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "chrono",
  "concordium_base",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-wallet-crypto-uniffi"
-version = "5.1.0"
+version = "5.1.1"
 edition = "2021"
 
 [dependencies]

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
     targets: [
         overridableFrameworkTarget(
             name: "ConcordiumWalletCryptoUniffi",
-            url: "https://github.com/Concordium/concordium-wallet-crypto-swift/releases/download/build%2F5.1.0-0/ConcordiumWalletCryptoUniffi.xcframework.zip",
-            checksum: "433c6ed2583ba667257cbb3c7df22173bdfc16e29cb88daa470164eb8a090b2b"
+            url: "https://github.com/Concordium/concordium-wallet-crypto-swift/releases/download/build%2F5.1.1-0/ConcordiumWalletCryptoUniffi.xcframework.zip",
+            checksum: "bcdbfc55d81ed0e93ec76a80c8bdd75b85170568ad100866d665eec7961f897b"
         ),
         .target(
             name: "ConcordiumWalletCrypto",


### PR DESCRIPTION
#Purpose
- Improve V1 presentation conversion reliability and error reporting.

#Changes
- Replaced JSON map conversion for `ArInfos` with explicit `ArIdentity` + `ArInfo` mapping.
- Added explicit `LabeledContextProperty` conversion to base format with clearer errors.
- Improved error messages in `create_verifiable_presentation_v1` to pinpoint conversion failures.